### PR TITLE
Warn unused blocks with Enumerable#all? any? one? none?

### DIFF
--- a/array.c
+++ b/array.c
@@ -5809,6 +5809,9 @@ rb_ary_any_p(int argc, VALUE *argv, VALUE ary)
     rb_check_arity(argc, 0, 1);
     if (!len) return Qfalse;
     if (argc) {
+    if (rb_block_given_p()) {
+        rb_warn("given block not used");
+    }
 	for (i = 0; i < RARRAY_LEN(ary); ++i) {
 	    if (RTEST(rb_funcall(argv[0], idEqq, 1, RARRAY_AREF(ary, i)))) return Qtrue;
 	}

--- a/enum.c
+++ b/enum.c
@@ -1212,6 +1212,11 @@ name##_eqq(RB_BLOCK_CALL_FUNC_ARGLIST(i, memo)) \
 static VALUE \
 enum_##name##_func(VALUE result, struct MEMO *memo)
 
+#define ENUM_WARN_UNUSED_BLOCK(argc) \
+    if (argc > 0 && rb_block_given_p()) { \
+        rb_warn("given block not used"); \
+    }
+
 DEFINE_ENUMFUNCS(all)
 {
     if (!RTEST(result)) {
@@ -1249,6 +1254,7 @@ static VALUE
 enum_all(int argc, VALUE *argv, VALUE obj)
 {
     struct MEMO *memo = MEMO_ENUM_NEW(Qtrue);
+    ENUM_WARN_UNUSED_BLOCK(argc)
     rb_block_call(obj, id_each, 0, 0, ENUMFUNC(all), (VALUE)memo);
     return memo->v1;
 }
@@ -1290,6 +1296,7 @@ static VALUE
 enum_any(int argc, VALUE *argv, VALUE obj)
 {
     struct MEMO *memo = MEMO_ENUM_NEW(Qfalse);
+    ENUM_WARN_UNUSED_BLOCK(argc)
     rb_block_call(obj, id_each, 0, 0, ENUMFUNC(any), (VALUE)memo);
     return memo->v1;
 }
@@ -1557,6 +1564,7 @@ enum_one(int argc, VALUE *argv, VALUE obj)
     struct MEMO *memo = MEMO_ENUM_NEW(Qundef);
     VALUE result;
 
+    ENUM_WARN_UNUSED_BLOCK(argc)
     rb_block_call(obj, id_each, 0, 0, ENUMFUNC(one), (VALUE)memo);
     result = memo->v1;
     if (result == Qundef) return Qfalse;
@@ -1598,6 +1606,8 @@ static VALUE
 enum_none(int argc, VALUE *argv, VALUE obj)
 {
     struct MEMO *memo = MEMO_ENUM_NEW(Qtrue);
+
+    ENUM_WARN_UNUSED_BLOCK(argc)
     rb_block_call(obj, id_each, 0, 0, ENUMFUNC(none), (VALUE)memo);
     return memo->v1;
 }

--- a/hash.c
+++ b/hash.c
@@ -3034,6 +3034,9 @@ rb_hash_any_p(int argc, VALUE *argv, VALUE hash)
     rb_check_arity(argc, 0, 1);
     if (RHASH_EMPTY_P(hash)) return Qfalse;
     if (argc) {
+    if (rb_block_given_p()) {
+        rb_warn("given block not used");
+    }
 	args[1] = argv[0];
 
 	rb_hash_foreach(hash, any_p_i_pattern, (VALUE)args);

--- a/test/ruby/test_enum.rb
+++ b/test/ruby/test_enum.rb
@@ -314,6 +314,21 @@ class TestEnumerable < Test::Unit::TestCase
     assert_equal(false, @obj.all?(1..2))
   end
 
+  def test_all_with_unused_block
+    assert_in_out_err [], <<-EOS, [], ["-:1: warning: given block not used"]
+      [1, 2].all?(1) {|x| x == 3 }
+    EOS
+    assert_in_out_err [], <<-EOS, [], ["-:1: warning: given block not used"]
+      (1..2).all?(1) {|x| x == 3 }
+    EOS
+    assert_in_out_err [], <<-EOS, [], ["-:1: warning: given block not used"]
+      3.times.all?(1) {|x| x == 3 }
+    EOS
+    assert_in_out_err [], <<-EOS, [], ["-:1: warning: given block not used"]
+      {a: 1, b: 2}.all?([:b, 2]) {|x| x == 4 }
+    EOS
+  end
+
   def test_any
     assert_equal(true, @obj.any? {|x| x >= 3 })
     assert_equal(false, @obj.any? {|x| x > 3 })
@@ -327,6 +342,21 @@ class TestEnumerable < Test::Unit::TestCase
     assert_equal(true, [1, 4.2].any?(Float))
     assert_equal(false, {a: 1, b: 2}.any?(->(kv) { kv == [:foo, 42] }))
     assert_equal(true, {a: 1, b: 2}.any?(->(kv) { kv == [:b, 2] }))
+  end
+
+  def test_any_with_unused_block
+    assert_in_out_err [], <<-EOS, [], ["-:1: warning: given block not used"]
+      [1, 23].any?(1) {|x| x == 1 }
+    EOS
+    assert_in_out_err [], <<-EOS, [], ["-:1: warning: given block not used"]
+      (1..2).any?(34) {|x| x == 2 }
+    EOS
+    assert_in_out_err [], <<-EOS, [], ["-:1: warning: given block not used"]
+      3.times.any?(1) {|x| x == 3 }
+    EOS
+    assert_in_out_err [], <<-EOS, [], ["-:1: warning: given block not used"]
+      {a: 1, b: 2}.any?([:b, 2]) {|x| x == 4 }
+    EOS
   end
 
   def test_one
@@ -348,6 +378,21 @@ class TestEnumerable < Test::Unit::TestCase
     assert([ nil, true, 99 ].one?(Integer))
   end
 
+  def test_one_with_unused_block
+    assert_in_out_err [], <<-EOS, [], ["-:1: warning: given block not used"]
+      [1, 2].one?(1) {|x| x == 3 }
+    EOS
+    assert_in_out_err [], <<-EOS, [], ["-:1: warning: given block not used"]
+      (1..2).one?(1) {|x| x == 3 }
+    EOS
+    assert_in_out_err [], <<-EOS, [], ["-:1: warning: given block not used"]
+      3.times.one?(1) {|x| x == 3 }
+    EOS
+    assert_in_out_err [], <<-EOS, [], ["-:1: warning: given block not used"]
+      {a: 1, b: 2}.one?([:b, 2]) {|x| x == 4 }
+    EOS
+  end
+
   def test_none
     assert(@obj.none? {|x| x == 4 })
     assert(!(@obj.none? {|x| x == 1 }))
@@ -363,6 +408,21 @@ class TestEnumerable < Test::Unit::TestCase
     assert([nil,false].none?)
     assert(![nil,false,true].none?)
     assert(@empty.none?)
+  end
+
+  def test_none_with_unused_block
+    assert_in_out_err [], <<-EOS, [], ["-:1: warning: given block not used"]
+      [1, 2].none?(1) {|x| x == 3 }
+    EOS
+    assert_in_out_err [], <<-EOS, [], ["-:1: warning: given block not used"]
+      (1..2).none?(1) {|x| x == 3 }
+    EOS
+    assert_in_out_err [], <<-EOS, [], ["-:1: warning: given block not used"]
+      3.times.none?(1) {|x| x == 3 }
+    EOS
+    assert_in_out_err [], <<-EOS, [], ["-:1: warning: given block not used"]
+      {a: 1, b: 2}.none?([:b, 2]) {|x| x == 4 }
+    EOS
   end
 
   def test_min


### PR DESCRIPTION
Let Array#any? (and related enumerable methods alike) to express warnings in case blocks are left unused.

# Background
Certain methods in Array silently ignore the given blocks without any warnings, which sometimes causes 'invisible' bugs that are a bit hard to detect.

```ruby
>> [1,2,3].any?(2) {|it| it > 10}
=> true
```

On the other hand, Array#index warns you (kindly enough!) when your blocks are left unused.

```ruby
>> [1,2,3].index(2) {|it| it > 10}
(irb):3: warning: given block not used
=> 1
```

# Proposal
This PR is to let Enumerable#all?, #any?, #one, #none?  (including similar methods with Array and Hash) to show warning messages so as that it behaves in consistent manner with what we see with Array#index.

# Implementation
https://github.com/fursich/ruby/pull/1

Adding one conditional branch per one method call, which would cost very low in terms of computational cost. (benchmark-driver suggested somewhere around 1.00x-1.01x slower with Enumurator#any?)

Hopefully it would reduce some of the unnecessary source of pain embedded in the running codes, and help us code happily;)